### PR TITLE
fieldErrorMessages variable should not be an undefined

### DIFF
--- a/src/validate.jsx
+++ b/src/validate.jsx
@@ -55,7 +55,7 @@ class Validate extends Component {
       fieldValue = e.value;
     }
 
-    const fieldErrorMessages = this.testForValidation(fieldName, fieldValue);
+    const fieldErrorMessages = this.testForValidation(fieldName, fieldValue) || [];
     const allErrors = Object.assign(
         {},
         this.state.errorMessages,


### PR DESCRIPTION
in the `handleValidate` method sometimes variable `fieldErrorMessages` can be undefined:
https://github.com/js2me/react-validate-form/blob/master/src/validate.jsx#L58
```
const fieldErrorMessages = this.testForValidation(fieldName, fieldValue);
```
and after this code line value from this variables trying to split on keys of the object:
https://github.com/js2me/react-validate-form/blob/master/src/validate.jsx#L15
```
const total = acc += Object.keys(errorObject[curr]).length; // there is should be Object.keys(undefined).length
```
And of course, when we send `undefined` to Object.keys method then we've got an error
![image](https://user-images.githubusercontent.com/16340911/43630071-da86cf50-9707-11e8-8d0c-00a5631456a7.png)

That PR solves this problem